### PR TITLE
Add additional role checker

### DIFF
--- a/src/Orchestra/Auth/Guard.php
+++ b/src/Orchestra/Auth/Guard.php
@@ -86,6 +86,87 @@ class Guard extends \Illuminate\Auth\Guard
     }
 
     /**
+     * Determine if current user has any of the given role.
+     *
+     * @param  array   $roles
+     * @return boolean
+     */
+    public function isAny(array $roles)
+    {
+        $userRoles = $this->roles();
+
+        // For a pre-caution, we should return false in events where user
+        // roles not an array.
+        if (! is_array($userRoles)) {
+            return false;
+        }
+
+        // We should ensure that any given roles match the current user,
+        // consider it as OR condition.
+        foreach ($roles as $role) {
+            if (in_array($role, $userRoles)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if current user does not has any of the given role.
+     *
+     * @param  string   $roles
+     * @return boolean
+     */
+    public function isNot($roles)
+    {
+        $userRoles = $this->roles();
+
+        // For a pre-caution, we should return false in events where user
+        // roles not an array.
+        if (! is_array($userRoles)) {
+            return false;
+        }
+
+        // We should ensure that any given roles does not match the current
+        // user, consider it as OR condition.
+        foreach ((array) $roles as $role) {
+            if (in_array($role, $userRoles)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if current user does not has any of the given role.
+     *
+     * @param  array   $roles
+     * @return boolean
+     */
+    public function isNotAny(array $roles)
+    {
+        $userRoles = $this->roles();
+
+        // For a pre-caution, we should return false in events where user
+        // roles not an array.
+        if (! is_array($userRoles)) {
+            return false;
+        }
+
+        // We should ensure that any given roles does not match the current user,
+        // consider it as OR condition.
+        foreach ($roles as $role) {
+            if (! in_array($role, $userRoles)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function logout()

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -175,6 +175,157 @@ class GuardTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test Orchestra\Support\Auth::isAny() method returning valid roles.
+     *
+     * @test
+     */
+    public function testIsAnyMethod()
+    {
+        $events = $this->events;
+
+        $user = m::mock('\Illuminate\Auth\UserInterface');
+        $user->id = 1;
+
+        $events->shouldReceive('until')->once()
+                ->with('orchestra.auth: roles', m::any())->andReturn(array('admin', 'editor'));
+
+        $stub = new Guard($this->provider, $this->session);
+        $stub->setDispatcher($events);
+        $stub->setUser($user);
+
+        $this->assertTrue($stub->isAny(array('admin', 'user')));
+        $this->assertTrue($stub->isAny(array('user', 'editor')));
+        $this->assertFalse($stub->isAny(array('superadmin', 'user')));
+    }
+
+    /**
+     * Test Orchestra\Support\Auth::isAny() method when invalid roles is
+     * returned.
+     *
+     * @test
+     */
+    public function testIsAnyMethodWhenInvalidRolesIsReturned()
+    {
+        $events = $this->events;
+        $user   = m::mock('\Illuminate\Auth\UserInterface');
+        $user->id = 1;
+
+        $events->shouldReceive('until')
+                ->with('orchestra.auth: roles', m::any())->once()
+                ->andReturn('foo');
+
+        $stub = new Guard($this->provider, $this->session);
+        $stub->setDispatcher($events);
+        $stub->setUser($user);
+
+        $this->assertFalse($stub->isAny(array('admin', 'editor')));
+        $this->assertFalse($stub->isAny(array('admin', 'user')));
+    }
+
+    /**
+     * Test Orchestra\Support\Auth::isNot() method returning valid roles.
+     *
+     * @test
+     */
+    public function testIsNotMethod()
+    {
+        $events = $this->events;
+
+        $user = m::mock('\Illuminate\Auth\UserInterface');
+        $user->id = 1;
+
+        $events->shouldReceive('until')->once()
+                ->with('orchestra.auth: roles', m::any())->andReturn(array('admin', 'editor'));
+
+        $stub = new Guard($this->provider, $this->session);
+        $stub->setDispatcher($events);
+        $stub->setUser($user);
+
+        $this->assertTrue($stub->isNot('superadmin'));
+        $this->assertTrue($stub->isNot('user'));
+        $this->assertFalse($stub->isNot('admin'));
+
+        $this->assertTrue($stub->isNot(array('superadmin', 'user')));
+        $this->assertFalse($stub->isNot(array('admin', 'editor')));
+    }
+
+    /**
+     * Test Orchestra\Support\Auth::isNot() method when invalid roles is
+     * returned.
+     *
+     * @test
+     */
+    public function testIsNotMethodWhenInvalidRolesIsReturned()
+    {
+        $events = $this->events;
+        $user   = m::mock('\Illuminate\Auth\UserInterface');
+        $user->id = 1;
+
+        $events->shouldReceive('until')
+                ->with('orchestra.auth: roles', m::any())->once()
+                ->andReturn('foo');
+
+        $stub = new Guard($this->provider, $this->session);
+        $stub->setDispatcher($events);
+        $stub->setUser($user);
+
+        $this->assertFalse($stub->isNot('admin'));
+        $this->assertFalse($stub->isNot('editor'));
+        $this->assertFalse($stub->isNot('user'));
+
+        $this->assertFalse($stub->isNot(array('admin', 'editor')));
+        $this->assertFalse($stub->isNot(array('admin', 'user')));
+    }
+
+    /**
+     * Test Orchestra\Support\Auth::isAny() method returning valid roles.
+     *
+     * @test
+     */
+    public function testIsNotAnyMethod()
+    {
+        $events = $this->events;
+
+        $user = m::mock('\Illuminate\Auth\UserInterface');
+        $user->id = 1;
+
+        $events->shouldReceive('until')->once()
+                ->with('orchestra.auth: roles', m::any())->andReturn(array('admin', 'editor'));
+
+        $stub = new Guard($this->provider, $this->session);
+        $stub->setDispatcher($events);
+        $stub->setUser($user);
+
+        $this->assertTrue($stub->isNotAny(array('admin', 'user')));
+        $this->assertTrue($stub->isNotAny(array('user', 'editor')));
+        $this->assertFalse($stub->isNotAny(array('admin', 'editor')));
+    }
+
+    /**
+     * Test Orchestra\Support\Auth::isNotAny() method when invalid roles is
+     * returned.
+     *
+     * @test
+     */
+    public function testIsNotAnyMethodWhenInvalidRolesIsReturned()
+    {
+        $events = $this->events;
+        $user   = m::mock('\Illuminate\Auth\UserInterface');
+        $user->id = 1;
+
+        $events->shouldReceive('until')
+                ->with('orchestra.auth: roles', m::any())->once()
+                ->andReturn('foo');
+
+        $stub = new Guard($this->provider, $this->session);
+        $stub->setDispatcher($events);
+        $stub->setUser($user);
+
+        $this->assertFalse($stub->isNotAny(array('admin', 'editor')));
+        $this->assertFalse($stub->isNotAny(array('admin', 'user')));
+    }
+
+    /**
      * Test Orchestra\Support\Auth::logout() method.
      *
      * @test


### PR DESCRIPTION
Add additional role checker.

``` php
Auth::isNot(['foo', 'bar']) //check if user does not have the roles

Auth::isAny(['foo', 'bar']) //check if user has any one of the roles

Auth::isNotAny(['foo', 'bar']) //check if user does not has any one of the roles
```

Signed-off-by: ahmadshah ahmadshahhafizan@gmail.com
