### PR TITLE
Added `setName()` method

### DIFF
--- a/src/Authorization/Authorization.php
+++ b/src/Authorization/Authorization.php
@@ -28,13 +28,27 @@ class Authorization implements AuthorizationContract
      */
     public function __construct($name, Provider $memory = null)
     {
-        $this->name = $name;
+        $this->setName($name);
 
         $this->roles   = new Fluent('roles');
         $this->actions = new Fluent('actions');
 
         $this->roles->add('guest');
         $this->attach($memory);
+    }
+
+    /**
+     * Set the authorization name.
+     *
+     * @param string $name
+     *
+     * @return $this
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Having the ability to set the name allows for easier construction of a new custom ACL instance with it's current memory driver. For example:

``` php
$acl = Foundation::acl();

$acl->setName('Custom ACL');
```
